### PR TITLE
ERROR(Named arguments) -- softmax_cross_entropy_with_logits

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -95,7 +95,7 @@ biases = {
 pred = conv_net(x, weights, biases, keep_prob)
 
 # Define loss and optimizer
-cost = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(pred, y))
+cost = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(logits = pred, labels = y))
 optimizer = tf.train.AdamOptimizer(learning_rate=learning_rate).minimize(cost)
 
 # Evaluate model


### PR DESCRIPTION
In recent tensorflow versions(i am using 1.140) "softmax_cross_entropy_with_logits" doesn't take arguments without names. Hence this gave an error. It can be fixed by naming arguments "logits" and "labels" as i did in the changes proposed.